### PR TITLE
Add ssl

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -27,6 +27,7 @@ Slurper requires a slurper_config.yml file in your working directory. This file 
   project_id: 1234
   token: 123abc123abc123abc
   requested_by: Jane Stakeholder
+  ssl: true
 
 The project_id tells tracker which project to add your stories to. It can be found on the project settings or the url for the project.
 
@@ -34,11 +35,8 @@ The token can be found on your personal profile page in Pivotal Tracker.
 
 The requested_by field should be the name of your project stakeholder exactly as it appears in tracker.
 
-  ssl: true
-
+The ssl field should be set to true if you've enabled "Use HTTPS" in Pivotal Tracker.
 SSL is being verified by peer using the cacert.pem from (http://curl.haxx.se/ca)
-
-If your tracker project has "Use HTTPS" enabled then you'll want to add the above line to your config file.
 
 == Usage
 


### PR DESCRIPTION
I added ssl support with tests and the cacert from cURL.haxx.se. It'd be nice to have this integrated so I can use slurper and ssl.
