### PR TITLE
Setting YAML engine breaks slurper for Ruby 1.8.7

### DIFF
--- a/lib/slurper.rb
+++ b/lib/slurper.rb
@@ -1,6 +1,6 @@
 require 'yaml'
 require 'story'
-YAML::ENGINE.yamler='syck'
+YAML::ENGINE.yamler='syck' if RUBY_VERSION > '1.9'
 
 
 class Slurper


### PR DESCRIPTION
When you set the YAML engine it breaks support for ruby 1.8. I added a check to only set the YAML engine only when on Ruby 1.9. 
