### PR TITLE
Update link to vim-slurper

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,7 @@
 
 Slurper allows you to quickly compose your stories in a text file and import them into Pivotal Tracker.
 
-Works great with slurper.vim! (http://github.com/alowe/vim-slurper)
+Works great with slurper.vim! (http://github.com/adamlowe/vim-slurper)
 
 == Note on Patches/Pull Requests
 


### PR DESCRIPTION
Adam must have changed his github username, the link to vim-slurper in the readme no longer works.  This patch updates the link to work correctly.
