### PR TITLE
Accept a YAML array for labels

### DIFF
--- a/lib/slurper/story.rb
+++ b/lib/slurper/story.rb
@@ -41,9 +41,14 @@ module Slurper
 
     def labels
       return [] unless attributes[:labels].present?
-      attributes[:labels].split(',').map do |tag|
-        {name: tag}
-      end
+
+      array = if attributes[:labels].is_a? Array
+                attributes[:labels]
+              else
+                attributes[:labels].split ','
+              end
+
+      array.map { |tag| { name: tag } }
     end
 
     def requested_by

--- a/spec/fixtures/array_of_labels.slurper
+++ b/spec/fixtures/array_of_labels.slurper
@@ -1,0 +1,9 @@
+==
+story_type:
+  feature
+name:
+  Catchy Song
+labels:
+  - verse
+  - chorus
+  - hook

--- a/spec/lib/slurper/engine_spec.rb
+++ b/spec/lib/slurper/engine_spec.rb
@@ -53,4 +53,9 @@ describe Slurper::Engine do
     its(:estimate) { should == 3 }
     its(:requested_by) { should == 'Joe Developer' }
   end
+
+  context "given a story with an array of labels" do
+    let(:filename) { 'array_of_labels.slurper' }
+    its(:labels) { should == [{name:'verse'},{name:'chorus'},{name:'hook'}] }
+  end
 end

--- a/spec/lib/slurper/story_spec.rb
+++ b/spec/lib/slurper/story_spec.rb
@@ -107,6 +107,11 @@ describe Slurper::Story do
       let(:labels) { 'one,two' }
       it { should == [{name:'one'},{name:'two'}] }
     end
+
+    context 'with an array of labels' do
+      let(:labels) { %w[foo bar] }
+      it { should == [{name:'foo'},{name:'bar'}] }
+    end
   end
 
   describe "#requested_by" do


### PR DESCRIPTION
Hey there! :wave:

This is my first time using slurper and I must admit I didn't read the documentation very well, so I wrote a bunch of stories with labels like this:

``` yaml
labels:
  - faith
  - hope
  - love
```

Instead of like this:

``` yaml
labels: faith,hope,love
```

Anywho I think supporting both makes for a really nice & predictable interface especially for those irritating guys who don't RTFM like me :wink:

Have at it! :heart:
